### PR TITLE
Fill in description with selected text

### DIFF
--- a/bookmarker for pinboard extension/Info.plist
+++ b/bookmarker for pinboard extension/Info.plist
@@ -29,7 +29,12 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).SafariExtensionHandler</string>
 		<key>SFSafariContentScript</key>
-		<array/>
+		<array>
+			<dict>
+				<key>Script</key>
+				<string>script.js</string>
+			</dict>
+		</array>
 		<key>SFSafariToolbarItem</key>
 		<dict>
 			<key>Action</key>

--- a/bookmarker for pinboard extension/SafariExtensionHandler.swift
+++ b/bookmarker for pinboard extension/SafariExtensionHandler.swift
@@ -8,7 +8,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         // This method will be called when a content script provided by your extension calls safari.extension.dispatchMessage("message").
         page.getPropertiesWithCompletionHandler { properties in
             
-            NSLog("The extension received a message (\(messageName)) from a script injected into (\(String(describing: properties?.url))) with userInfo (\(userInfo ?? [:]))")
+            //NSLog("The extension received a message (\(messageName)) from a script injected into (\(String(describing: properties?.url))) with userInfo (\(userInfo ?? [:]))")
             
             if let selectedText = userInfo?["text"] {
                 DispatchQueue.main.async {

--- a/bookmarker for pinboard extension/SafariExtensionHandler.swift
+++ b/bookmarker for pinboard extension/SafariExtensionHandler.swift
@@ -7,7 +7,19 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     override func messageReceived(withName messageName: String, from page: SFSafariPage, userInfo: [String : Any]?) {
         // This method will be called when a content script provided by your extension calls safari.extension.dispatchMessage("message").
         page.getPropertiesWithCompletionHandler { properties in
+            
             NSLog("The extension received a message (\(messageName)) from a script injected into (\(String(describing: properties?.url))) with userInfo (\(userInfo ?? [:]))")
+            
+            if let selectedText = userInfo?["text"] {
+                DispatchQueue.main.async {
+                    SafariExtensionViewController.shared.descriptionTextField.stringValue = selectedText as! String
+                }
+            }
+            else {
+                DispatchQueue.main.async {
+                    SafariExtensionViewController.shared.descriptionTextField.stringValue = ""
+                }
+            }
         }
     }
     
@@ -31,11 +43,11 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
             activeTab in activeTab?.getActivePage {
                 activePage in activePage?.getPropertiesWithCompletionHandler {
                     pageProperties in
+                    activePage?.dispatchMessageToScript(withName: "getSelectedText", userInfo: nil)
                     if let title = pageProperties?.title, let url = pageProperties?.url {
                         DispatchQueue.main.async {
                             SafariExtensionViewController.shared.urlTextField.stringValue = url.absoluteString
                             SafariExtensionViewController.shared.titleTextField.stringValue = title
-                            SafariExtensionViewController.shared.descriptionTextField.stringValue = ""
                             SafariExtensionViewController.shared.tagsTextField.stringValue = ""
                             SafariExtensionViewController.shared.statusTextField.stringValue = ""
                         }
@@ -43,7 +55,6 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
                         DispatchQueue.main.async {
                             SafariExtensionViewController.shared.urlTextField.stringValue = ""
                             SafariExtensionViewController.shared.titleTextField.stringValue = ""
-                            SafariExtensionViewController.shared.descriptionTextField.stringValue = ""
                             SafariExtensionViewController.shared.tagsTextField.stringValue = ""
                             SafariExtensionViewController.shared.statusTextField.stringValue = ""
                         }

--- a/bookmarker for pinboard extension/script.js
+++ b/bookmarker for pinboard extension/script.js
@@ -2,15 +2,42 @@ if (window.top === window) {
     // The parent frame is the top-level frame, not an iframe.
     // All non-iframe code goes before the closing brace.
     
+    var selectedText = ""
+    var numberConsecutiveEmptySelections = 0
+    
     var handleMessage = function (event) {
-        console.log("(bookmarker for pinboard) Get message from extension %s.",event.name);
+        //console.log("(bookmarker for pinboard) Got message from extension %s.", event.name);
         switch(event.name) {
             case "getSelectedText" :
-                safari.extension.dispatchMessage("selectedText", {"text": window.getSelection().toString()} );
+                safari.extension.dispatchMessage("selectedText", {"text": selectedText} );
         }
     }
     
     document.addEventListener("DOMContentLoaded", function(event) {
-                              safari.self.addEventListener("message", handleMessage);
+                                safari.self.addEventListener("message", handleMessage);
+                              });
+    
+    document.addEventListener("selectionchange", () => {
+                                // This implementation with 'numberConsecutiveEmptySelections' is implemented
+                                // to work around and ignore the deselect of text when we press the toolbar button.
+                                // We store the selected text in the 'selectedText' variable but only empty it if we got
+                                // two or more consecutive empty selections. This means following sequences work :
+                                // a. 1. User selects text.  2. selection is lost when user presses toolbar button (outside of our control)
+                                // b. 1. User deselects text. 2. selection is lost when user presses toolbar button (outside of our control)
+                              
+                                // In a. the user selected text will appear in the Description field as expected.
+                                // In b. the Description field will be empty as expected.
+                              
+                                newSelection = window.getSelection().toString()
+                                if (newSelection == "") {
+                                    numberConsecutiveEmptySelections++
+                                    if (numberConsecutiveEmptySelections >= 2) {
+                                        selectedText = ""
+                                    }
+                                } else {
+                                    selectedText = newSelection
+                                    numberConsecutiveEmptySelections = 0
+                                }
+                                //console.log(selectedText);
                               });
 }

--- a/bookmarker for pinboard extension/script.js
+++ b/bookmarker for pinboard extension/script.js
@@ -1,0 +1,16 @@
+if (window.top === window) {
+    // The parent frame is the top-level frame, not an iframe.
+    // All non-iframe code goes before the closing brace.
+    
+    var handleMessage = function (event) {
+        console.log("(bookmarker for pinboard) Get message from extension %s.",event.name);
+        switch(event.name) {
+            case "getSelectedText" :
+                safari.extension.dispatchMessage("selectedText", {"text": window.getSelection().toString()} );
+        }
+    }
+    
+    document.addEventListener("DOMContentLoaded", function(event) {
+                              safari.self.addEventListener("message", handleMessage);
+                              });
+}

--- a/bookmarker for pinboard.xcodeproj/project.pbxproj
+++ b/bookmarker for pinboard.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6D020C2221EE725D00859606 /* CutCopyPasteTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D020C2121EE725D00859606 /* CutCopyPasteTextField.swift */; };
+		6D02EE6E228B248F0082B349 /* script.js in Resources */ = {isa = PBXBuildFile; fileRef = 6D02EE6D228B248F0082B349 /* script.js */; };
 		6D14370621DE3E340025FE25 /* PinboardUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D14370521DE3E340025FE25 /* PinboardUrl.swift */; };
 		6D59F41421D8FF5700143454 /* bookmarker for pinboard.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 6D59F41321D8FF5700143454 /* bookmarker for pinboard.entitlements */; };
 		6D59F41621D8FF5700143454 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D59F41521D8FF5700143454 /* AppDelegate.swift */; };
@@ -75,6 +76,7 @@
 
 /* Begin PBXFileReference section */
 		6D020C2121EE725D00859606 /* CutCopyPasteTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CutCopyPasteTextField.swift; sourceTree = "<group>"; };
+		6D02EE6D228B248F0082B349 /* script.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = script.js; sourceTree = "<group>"; };
 		6D14370521DE3E340025FE25 /* PinboardUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinboardUrl.swift; sourceTree = "<group>"; };
 		6D59F41021D8FF5700143454 /* bookmarker for pinboard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "bookmarker for pinboard.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D59F41321D8FF5700143454 /* bookmarker for pinboard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "bookmarker for pinboard.entitlements"; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 				6DEF337821DCD33800123E74 /* PinboardApi.swift */,
 				6DEF337C21DCE01D00123E74 /* PinboardApiResponse.swift */,
 				6D14370521DE3E340025FE25 /* PinboardUrl.swift */,
+				6D02EE6D228B248F0082B349 /* script.js */,
 			);
 			path = "bookmarker for pinboard extension";
 			sourceTree = "<group>";
@@ -396,6 +399,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6DC8FCEE21E20B9400997B80 /* pinboard_toolbar_icon.pdf in Resources */,
+				6D02EE6E228B248F0082B349 /* script.js in Resources */,
 				6D59F44C21D8FF5900143454 /* ToolbarItemIcon.pdf in Resources */,
 				6D59F44721D8FF5900143454 /* SafariExtensionViewController.xib in Resources */,
 			);


### PR DESCRIPTION
This implements #7.

When the popup opens we get the selected text from the active page and use it to populate
the description field. This is implemented by sending messages between the app extension
and a script that's injected in the web page.