### PR TITLE
Attempt to open popover using keyboard shortcut

### DIFF
--- a/bookmarker for pinboard extension/SafariExtensionHandler.swift
+++ b/bookmarker for pinboard extension/SafariExtensionHandler.swift
@@ -18,6 +18,14 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
                         SafariExtensionViewController.shared.descriptionTextField.stringValue = ""
                     }
                 }
+            case "openPopover" :
+                page.getContainingTab { (tab) in
+                    tab.getContainingWindow(completionHandler: { (window) in
+                        window?.getToolbarItem(completionHandler: { (toolbaritem) in
+                            toolbaritem?.showPopover()
+                        })
+                    })
+                }
             default :
                 NSLog("Received unsupported message: \(messageName)")
         }

--- a/bookmarker for pinboard extension/script.js
+++ b/bookmarker for pinboard extension/script.js
@@ -40,4 +40,10 @@ if (window.top === window) {
                                 }
                                 //console.log(selectedText);
                               });
+    
+    document.addEventListener("keydown", function (keyDownEvent) {
+                                if (keyDownEvent.ctrlKey && keyDownEvent.altKey && keyDownEvent.key === "a") {
+                                    safari.extension.dispatchMessage("openPopover");
+                                }
+                              });
 }


### PR DESCRIPTION
Detect keyboard shortcut in injected script and notify extension.
This part works but when receiving message I don't have access to SFSafariWindow,
only to SFSafariPage. This doesn't allow me to get access to ToolBarItem.